### PR TITLE
Correct bundle identifier

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -61,7 +61,7 @@
         "icons/icon.icns",
         "icons/icon.ico"
       ],
-      "identifier": "com.lume.nu",
+      "identifier": "nu.lume",
       "longDescription": "",
       "macOS": {
         "entitlements": null,


### PR DESCRIPTION
Bundle identifiers conventionally use https://en.wikipedia.org/wiki/Reverse_domain_name_notation so unless you own the cannabis shop at https://www.lume.com/ you should not be using `com.lume.anything` as your identifier.

Be aware that this changes the paths for user data so data may appear to be lost unless a migration is performed.