### PR TITLE
add libappindicator to runtime libs in nix shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,8 @@
           glib
           dbus
           openssl_3
-          librsvg     
+          librsvg
+          libappindicator-gtk3
         ];
 
         packages = with pkgs; [


### PR DESCRIPTION
Running on NixOS, attempting to run `pnpm tauri dev` will fail without this runtime library linked. 
`pnpm tauri build` will still fail on NixOS for other reasons. The dev app won't fully run either, but this gets us to the welcome screen at least.